### PR TITLE
Acceptors and message structure

### DIFF
--- a/our-paxos/paxos.py
+++ b/our-paxos/paxos.py
@@ -129,7 +129,7 @@ def acceptor(config, id):
                 msg = paxos_encode([instance, phase, state['rnd'], state['v-rnd'], state['v-val']])
                 s.sendto(msg, config['proposers'])
         elif phase == 2:
-            # received phase 1A msg from proposer
+            # received phase 2A msg from proposer
             # loc[2] = c-rnd, loc[3] = c-val
             if loc[2] >= state['rnd']:
                 #state['rnd'] = loc[2] # not in the slides, but it makes sense (?)
@@ -139,7 +139,7 @@ def acceptor(config, id):
 
                 # encode and send phase 2B to proposer
                 msg = paxos_encode([instance, phase, state['v-rnd'], state['v-val']])
-                s.sendto(msg, config['proposers'])
+                s.sendto(msg, config['learners'])
         else:
             print('Wrong message received: unknown phase. loc: {}'.format(loc))
 
@@ -184,15 +184,15 @@ def learner(config, id):
         # If id is > len(msg) we need to extend array of messages up to the needed size,
         # we don't show that we learned anything, bc we've extended array without assigning
         # the message with the smaller id
-        if id > len(msg):
-            while(id - 1 > len(msg)):
+        if id > len(messages):
+            while(id - 1 > len(messages)):
                 messages.append(-1)
             messages.append(value)
         # If id is = len(msg) we apppend a message to the array,
         # we don't show that we learned anything if learned isn't equal to msg len
         # because in this case we're still missing message somewhere in the middle
-        elif id == len(msg):
-            if learned == len(msg):
+        elif id == len(messages):
+            if learned == len(messages):
                 print("Learned: ", value)
                 learned+=1
             messages.append(value)
@@ -200,7 +200,7 @@ def learner(config, id):
         # If id is < len(msg) we swap -1 (value of not received message) with the received value,
         # then if id == learned, then we can print the value as learned until we reach first
         # undefined message
-        elif id < len(msg):
+        elif id < len(messages):
             messages[id] = value
             if id == learned:
                 while(messages[learned] != -1 and len(messages) > learned):

--- a/run.sh
+++ b/run.sh
@@ -38,13 +38,13 @@ echo "starting proposers..."
 ./proposer.sh 2 $conf &
 
 echo "waiting to start clients"
-sleep 10
+sleep 3
 echo "starting clients..."
 
 ./client.sh 1 $conf < ../prop1 &
 ./client.sh 2 $conf < ../prop2 &
 
-sleep 5
+sleep 3
 
 $KILLCMD
 wait

--- a/run_1acceptor.sh
+++ b/run_1acceptor.sh
@@ -36,13 +36,13 @@ echo "starting proposers..."
 ./proposer.sh 2 $conf &
 
 echo "waiting to start clients"
-sleep 10
+sleep 3
 echo "starting clients..."
 
 ./client.sh 1 $conf < ../prop1 &
 ./client.sh 2 $conf < ../prop2 &
 
-sleep 5
+sleep 3
 
 $KILLCMD
 wait


### PR DESCRIPTION
I defined a message structure for the Paxos phase variables and added methods to encode and decode an ordered list into a binary message that can be sent over the network. <br>
It can be used to communicate between the actors (proposer, acceptors, learner).

Acceptor function implemented accordingly with a dummy proposer for testing.

### Message structure
Basically an arbitrary number of chunks of 2 bytes each. At the moment only positive integer values in the range 0-65535  are accepted (is it enough?). More details in the code comments.

Example 
- phase 1A: <instance_number><phase_ID><c-rnd>
- phase 2A:  <instance_number><phase_ID><c-rnd><c-val>
where <..> = chunk = 2 bytes.

### Encode and decode
Convert between a "list of chunks" (list of integers) with each chunk corresponding to a separate value that we want to transmit. Order and content depend on the phase.

- encode **phase 1A**:  [1,2,3] -> binary message 
- decode  **phase 1A**:  binary message -> [1,2,3] 

@BritikovKI I changed you learner implementation to reflect the message structure. Let me know if it's fine. Also when you do `if id < len(msg):` is `len(msg)` just used as a number to compare to `id` or does the length actually matter? If it's the first, maybe we could use something smaller that 2**16? :D 
 
