### PR TITLE
Acceptors changes for learner

### DIFF
--- a/our-paxos/paxos.py
+++ b/our-paxos/paxos.py
@@ -153,7 +153,6 @@ def acceptor(config, id):
             
              # loc[2] = c-rnd, loc[3] = c-val
              if loc[2] >= state['rnd']:
-                #state['rnd'] = loc[2] # not in the slides, but it makes sense (?)
                 state['v-rnd'] = loc[2]
                 state['v-val'] = loc[3]
                 print("i: {} p: {}, state: {}".format(id, phase, state))
@@ -289,24 +288,24 @@ def learner(config, id):
                 elif inst_id < len(messages):
                     # print("Init les: {}, msg: {}, learned: {}, quorum: {}".format(inst_id, messages[inst_id], learned, QUORUM_AMOUNT))
                     if len(messages[inst_id]) >= QUORUM_AMOUNT - 1 and inst_id == learned:
-                        messages[inst_id].append(value)
                         print("Inside if: {}".format(learned))
-                        while(len(messages) > learned and len(messages[learned]) >= QUORUM_AMOUNT ):
+                        while(len(messages) > learned and len(messages[learned]) >= QUORUM_AMOUNT - 1 ):
                             validity = True
                             for val in messages[learned]:
                                 if val != messages[learned][0]:
                                     validity = False
                                     break
                             if validity:
+                                messages[inst_id].append(value)
                                 print("Instance: {} Learned: {} Amount:{}".format(learned, messages[learned][0], len(messages[learned])))
                             learned += 1
                     else:
                         messages[inst_id].append(value)
-                    if len(messages[inst_id]) == 1:
-                        messages_running[inst_id] = True
-                        thread = Thread(target=learner_timeout, args=(inst_id))
-                        thread.start()
-                        thread.join()
+                if len(messages[inst_id]) == 1:
+                    messages_running[inst_id] = True
+                    thread = Thread(target=learner_timeout, args=(inst_id))
+                    thread.start()
+                    thread.join()
 
 
             # If we received Learner update message, and we need to propagate the data that we know

--- a/our-paxos/paxos.py
+++ b/our-paxos/paxos.py
@@ -162,8 +162,9 @@ def acceptor(config, id):
                 s.sendto(msg, config['learners'])
         
         elif phase == 4: # received "resend 2B" request from learner timeout
-            msg = paxos_encode([id, 2, state['v-rnd'], state['v-val']])
-            s.sendto(msg, config['learners'])
+            if state['v-rnd'] != 0:
+                msg = paxos_encode([id, 2, state['v-rnd'], state['v-val']])
+                s.sendto(msg, config['learners'])
         
         else:
             print('Wrong message received: unknown phase. loc: {}'.format(loc))

--- a/our-paxos/paxos.py
+++ b/our-paxos/paxos.py
@@ -35,8 +35,6 @@ def parse_cfg(cfgpath):
     return cfg
 
 
-# ----------------------------------------------------
-
 def paxos_encode(loc):
     """Encode a paxos message into binary, to be sent through a network
     socket.
@@ -72,7 +70,6 @@ def paxos_encode(loc):
     # put size as last element
     msg = msg << 16 | len(loc)
     nbytes += 2
-
     #encode
     return msg.to_bytes(nbytes, 'big', signed=True)
 
@@ -95,6 +92,8 @@ def paxos_decode(msg_bin):
         msg = msg >> 16
     
     return loc
+
+# ----------------------------------------------------
 
 def acceptor(config, id):
     print ('-> acceptor', id)
@@ -219,16 +218,6 @@ def proposer(config, id):
     phase2A_msg = paxos_encode([1, 2, id, proposal_number, proposal_value])
     s.sendto(phase2A_msg, config['acceptors'])
 
-
-# def learner(config, id):
-#     r = mcast_receiver(config['learners'])
-#     s = mcast_sender()
-#     while True:
-#         # TODO: check if id was already processed
-#         # We receive a message which consists out of id of the message and value of the message
-#         init =  r.recv(2**16)
-#         msg = paxos_decode(init) ## list (loc): [size, id, phase, round, value]
-#         print("Got:", msg)
 
 def learner(config, id):
     r = mcast_receiver(config['learners'])


### PR DESCRIPTION
(basically copied Konstantin code into acceptor lol)

- resending 2B message when receiving phase 4
- Acceptor timeout: start after sending 1B, if phase 2A message not received ask to restart consensus

⚠️ Things to double check:
- line 156
- is the phase 3 condition (accept if quorum of processes has c-rnd = v-rnd)? Do we care?
- What if init value is sent for learner timeout on acceptor?
- Quorum from same process issue - is there a case when we can get a quorum from the same acceptor combining timeout and message delay? Again, do we care?
- what happens when validity is broken in the learner?